### PR TITLE
Add async task cancel listener and multiple waypoint support

### DIFF
--- a/library/src/main/java/com/directions/route/AbstractRouting.java
+++ b/library/src/main/java/com/directions/route/AbstractRouting.java
@@ -68,6 +68,12 @@ public abstract class AbstractRouting<T> extends AsyncTask<T, Void, Route> {
         }
     }
 
+    private void dispatchOnCancelled() {
+        for (RoutingListener mListener : _aListeners) {
+            mListener.onRoutingCancelled();
+        }
+    }
+
     /**
      * Performs the call to the google maps API to acquire routing data and
      * deserializes it to a format the map can display.
@@ -105,4 +111,10 @@ public abstract class AbstractRouting<T> extends AsyncTask<T, Void, Route> {
             dispatchOnSuccess(mOptions, result);
         }
     }//end onPostExecute method
+
+    @Override
+    protected void onCancelled() {
+        dispatchOnCancelled();
+    }
+
 }

--- a/library/src/main/java/com/directions/route/Routing.java
+++ b/library/src/main/java/com/directions/route/Routing.java
@@ -13,8 +13,14 @@ public class Routing extends AbstractRouting<LatLng> {
     }
 
     protected String constructURL(LatLng... points) {
+        int len = points.length;
+
+        if (len < 2)
+            throw new IllegalArgumentException("Must supply at least two points to route between.");
+
+        // First and last points as start and destination respectively
         LatLng start = points[0];
-        LatLng dest = points[1];
+        LatLng dest = points[len - 1];
 
         final StringBuffer mBuf = new StringBuffer(AbstractRouting.DIRECTIONS_API_URL);
         mBuf.append("origin=");
@@ -25,8 +31,23 @@ public class Routing extends AbstractRouting<LatLng> {
         mBuf.append(dest.latitude);
         mBuf.append(',');
         mBuf.append(dest.longitude);
+
+        // If more than two points are supplied, use in-between points as waypoints
+        if (len > 2) {
+            mBuf.append("&waypoints=");
+            for (int i = 1; i < len - 1; i++) {
+                mBuf.append("via:"); // we don't want to parse the resulting JSON for 'legs'.
+                mBuf.append(points[i].latitude);
+                mBuf.append(",");
+                mBuf.append(points[i].longitude);
+                mBuf.append("|");
+            }
+            mBuf.setLength(mBuf.length() - 1);
+        }
+
         mBuf.append("&sensor=true&mode=");
         mBuf.append(_mTravelMode.getValue());
+
 
         return mBuf.toString();
     }

--- a/library/src/main/java/com/directions/route/RoutingListener.java
+++ b/library/src/main/java/com/directions/route/RoutingListener.java
@@ -8,4 +8,6 @@ public interface RoutingListener {
     public void onRoutingStart();
 
     public void onRoutingSuccess(PolylineOptions mPolyOptions, Route route);
+
+    public void onRoutingCancelled();
 }

--- a/sample/src/main/java/com/directions/sample/MainActivity.java
+++ b/sample/src/main/java/com/directions/sample/MainActivity.java
@@ -400,6 +400,11 @@ public class MainActivity extends AppCompatActivity implements RoutingListener, 
     }
 
     @Override
+    public void onRoutingCancelled() {
+        Log.i(LOG_TAG, "Routing was cancelled.");
+    }
+
+    @Override
     public void onConnectionFailed(ConnectionResult connectionResult) {
 
         Log.v(LOG_TAG,connectionResult.toString());


### PR DESCRIPTION
1. I have added a callback wrapper for [AsyncTask.OnCancelled()](http://developer.android.com/reference/android/os/AsyncTask.html#onCancelled()), useful if any UI modification is done in the other callbacks (onSuccess/onFailure). If the user moves away from the activity while directions are still being calculated then we can simply discard the results and avoid touching the UI at all.

2. Added rudimentary support for multiple waypoints as per [Using Waypoints in Routes](https://developers.google.com/maps/documentation/directions/#Waypoints)