### PR TITLE
Added ability to use a key for the API request

### DIFF
--- a/library/src/main/java/com/directions/route/AbstractRouting.java
+++ b/library/src/main/java/com/directions/route/AbstractRouting.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 public abstract class AbstractRouting extends AsyncTask<Void, Void, ArrayList<Route>> {
     protected ArrayList<RoutingListener> _aListeners;
 
-    protected static final String DIRECTIONS_API_URL = "http://maps.googleapis.com/maps/api/directions/json?";
+    protected static final String DIRECTIONS_API_URL = "https://maps.googleapis.com/maps/api/directions/json?";
 
     public enum TravelMode {
         BIKING("biking"),

--- a/library/src/main/java/com/directions/route/Routing.java
+++ b/library/src/main/java/com/directions/route/Routing.java
@@ -18,6 +18,7 @@ public class Routing extends AbstractRouting {
     private final int avoidKinds;
     private final boolean optimize;
     private final String language;
+    private final String key;
 
     private Routing(Builder builder) {
         super(builder.listener);
@@ -27,6 +28,7 @@ public class Routing extends AbstractRouting {
         this.optimize = builder.optimize;
         this.alternativeRoutes = builder.alternativeRoutes;
         this.language = builder.language;
+        this.key = builder.key;
     }
 
     protected String constructURL () {
@@ -83,6 +85,11 @@ public class Routing extends AbstractRouting {
             stringBuilder.append("&language=").append(language);
         }
 
+        // API key
+        if(key != null) {
+            stringBuilder.append("&key=").append(key);
+        }
+
         return stringBuilder.toString();
     }
 
@@ -95,6 +102,7 @@ public class Routing extends AbstractRouting {
         private RoutingListener listener;
         private boolean optimize;
         private String language;
+        private String key;
 
         public Builder () {
             this.travelMode = TravelMode.DRIVING;
@@ -104,6 +112,7 @@ public class Routing extends AbstractRouting {
             this.listener = null;
             this.optimize = false;
             this.language = null;
+            this.key = null;
         }
 
         public Builder travelMode (TravelMode travelMode) {
@@ -141,6 +150,11 @@ public class Routing extends AbstractRouting {
 
         public Builder language (String language) {
             this.language = language;
+            return this;
+        }
+
+        public Builder key(String key) {
+            this.key = key;
             return this;
         }
 


### PR DESCRIPTION
The commit adds the possibility for users to specify their own API key when accessing the Google Directions API, thus enabling more advanced features such as higher quotas and more waypoints.

To do so the API request must use SSL so the default API URL has been changed to use SSL instead of plain HTTP.