### PR TITLE
Added some more information about errors on the onRoutingFailure

### DIFF
--- a/library/src/main/java/com/directions/route/AbstractRouting.java
+++ b/library/src/main/java/com/directions/route/AbstractRouting.java
@@ -114,7 +114,7 @@ public abstract class AbstractRouting extends AsyncTask<Void, Void, ArrayList<Ro
      */
     @Override
     protected ArrayList<Route> doInBackground(Void... voids) {
-        ArrayList<Route> result = null;
+        ArrayList<Route> result = new ArrayList<Route>();
         try {
             result = new GoogleParser(constructURL()).parse();
         }catch(RouteException e){
@@ -132,9 +132,7 @@ public abstract class AbstractRouting extends AsyncTask<Void, Void, ArrayList<Ro
 
     @Override
     protected void onPostExecute(ArrayList<Route> result) {
-        if(mException != null){
-            dispatchOnFailure(mException);
-        } else if (result != null) {
+        if (!result.isEmpty()) {
             int shortestRouteIndex = 0;
             int minDistance = Integer.MAX_VALUE;
 
@@ -154,6 +152,8 @@ public abstract class AbstractRouting extends AsyncTask<Void, Void, ArrayList<Ro
                 result.get(i).setPolyOptions(mOptions);
             }
             dispatchOnSuccess(result, shortestRouteIndex);
+        } else {
+            dispatchOnFailure(mException);
         }
     }//end onPostExecute method
 

--- a/library/src/main/java/com/directions/route/GoogleParser.java
+++ b/library/src/main/java/com/directions/route/GoogleParser.java
@@ -20,7 +20,7 @@ public class GoogleParser extends XMLParser implements Parser {
      * Distance covered. *
      */
     private int distance;
-    
+
     /* Status code returned when the request succeeded */
     private String OK = "OK";
 

--- a/library/src/main/java/com/directions/route/GoogleParser.java
+++ b/library/src/main/java/com/directions/route/GoogleParser.java
@@ -20,6 +20,9 @@ public class GoogleParser extends XMLParser implements Parser {
      * Distance covered. *
      */
     private int distance;
+    
+    /* Status code returned when the request succeeded */
+    private String OK = "OK";
 
     public GoogleParser(String feedUrl) {
         super(feedUrl);
@@ -31,17 +34,23 @@ public class GoogleParser extends XMLParser implements Parser {
      * @return a Route object based on the JSON object by Haseem Saheed
      */
 
-    public ArrayList<Route> parse() {
+    public ArrayList<Route> parse() throws RouteException {
         ArrayList<Route> routes = new ArrayList<>();
 
         // turn the stream into a string
         final String result = convertStreamToString(this.getInputStream());
-        if (result == null) return null;
+        if (result == null) {
+            throw new RouteException("Result is null");
+        }
 
         try {
             //Tranform the string into a json object
             final JSONObject json = new JSONObject(result);
             //Get the route object
+
+            if(!json.getString("status").equals(OK)){
+                throw new RouteException(json);
+            }
 
             JSONArray jsonRoutes = json.getJSONArray("routes");
 
@@ -110,10 +119,8 @@ public class GoogleParser extends XMLParser implements Parser {
             }
 
         } catch (JSONException e) {
-            Log.e("Routing Error", e.getMessage());
-            return null;
+            throw new RouteException("JSONException. Msg: "+e.getMessage());
         }
-
         return routes;
     }
 

--- a/library/src/main/java/com/directions/route/Parser.java
+++ b/library/src/main/java/com/directions/route/Parser.java
@@ -4,5 +4,5 @@ import java.util.List;
 
 //. by Haseem Saheed
 public interface Parser {
-    List<Route> parse();
+    List<Route> parse() throws RouteException;
 }

--- a/library/src/main/java/com/directions/route/RouteException.java
+++ b/library/src/main/java/com/directions/route/RouteException.java
@@ -21,13 +21,12 @@ public class RouteException extends Exception {
             statusCode = "";
             message = "Parsing error";
             return;
-        }else{
-            try {
-                statusCode = json.getString(KEY_STATUS);
-                message = json.getString(KEY_MESSAGE);
-            } catch (JSONException e) {
-                Log.e(TAG, "JSONException while parsing RouteException argument. Msg: " + e.getMessage());
-            }
+        }
+        try {
+            statusCode = json.getString(KEY_STATUS);
+            message = json.getString(KEY_MESSAGE);
+        } catch (JSONException e) {
+            Log.e(TAG, "JSONException while parsing RouteException argument. Msg: " + e.getMessage());
         }
     }
 

--- a/library/src/main/java/com/directions/route/RouteException.java
+++ b/library/src/main/java/com/directions/route/RouteException.java
@@ -23,13 +23,10 @@ public class RouteException extends Exception {
             return;
         }else{
             try {
-                Log.d(TAG,"json: "+json.toString());
-                Log.d(TAG,"Before accessing key: "+KEY_STATUS);
                 statusCode = json.getString(KEY_STATUS);
-                Log.d(TAG,"Before accessing key: "+KEY_MESSAGE);
                 message = json.getString(KEY_MESSAGE);
             } catch (JSONException e) {
-                Log.d(TAG, "JSONException. Msg: "+e.getMessage());
+                Log.e(TAG, "JSONException while parsing RouteException argument. Msg: " + e.getMessage());
             }
         }
     }

--- a/library/src/main/java/com/directions/route/RouteException.java
+++ b/library/src/main/java/com/directions/route/RouteException.java
@@ -1,0 +1,49 @@
+package com.directions.route;
+
+import android.util.Log;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * Created by nelson on 1/13/16.
+ */
+public class RouteException extends Exception {
+    private static final String TAG = "RouteException";
+    private final String KEY_STATUS = "status";
+    private final String KEY_MESSAGE = "error_message";
+
+    private String statusCode;
+    private String message;
+
+    public RouteException(JSONObject json){
+        if(json == null){
+            statusCode = "";
+            message = "Parsing error";
+            return;
+        }else{
+            try {
+                Log.d(TAG,"json: "+json.toString());
+                Log.d(TAG,"Before accessing key: "+KEY_STATUS);
+                statusCode = json.getString(KEY_STATUS);
+                Log.d(TAG,"Before accessing key: "+KEY_MESSAGE);
+                message = json.getString(KEY_MESSAGE);
+            } catch (JSONException e) {
+                Log.d(TAG, "JSONException. Msg: "+e.getMessage());
+            }
+        }
+    }
+
+    public RouteException(String msg){
+        message = msg;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    public String getStatusCode() {
+        return statusCode;
+    }
+}

--- a/library/src/main/java/com/directions/route/Routing.java
+++ b/library/src/main/java/com/directions/route/Routing.java
@@ -89,7 +89,6 @@ public class Routing extends AbstractRouting {
         if(key != null) {
             stringBuilder.append("&key=").append(key);
         }
-
         return stringBuilder.toString();
     }
 

--- a/library/src/main/java/com/directions/route/RoutingListener.java
+++ b/library/src/main/java/com/directions/route/RoutingListener.java
@@ -3,7 +3,7 @@ package com.directions.route;
 import java.util.ArrayList;
 
 public interface RoutingListener {
-    void onRoutingFailure();
+    void onRoutingFailure(RouteException e);
 
     void onRoutingStart();
 

--- a/sample/src/main/java/com/directions/sample/MainActivity.java
+++ b/sample/src/main/java/com/directions/sample/MainActivity.java
@@ -17,6 +17,7 @@ import android.widget.Toast;
 
 import com.directions.route.AbstractRouting;
 import com.directions.route.Route;
+import com.directions.route.RouteException;
 import com.directions.route.Routing;
 import com.directions.route.RoutingListener;
 import com.google.android.gms.common.ConnectionResult;
@@ -40,7 +41,6 @@ import com.google.android.gms.maps.model.Polyline;
 import com.google.android.gms.maps.model.PolylineOptions;
 
 import java.util.ArrayList;
-import java.util.List;
 
 import butterknife.ButterKnife;
 import butterknife.InjectView;
@@ -362,10 +362,13 @@ public class MainActivity extends AppCompatActivity implements RoutingListener, 
 
 
     @Override
-    public void onRoutingFailure() {
+    public void onRoutingFailure(RouteException e) {
         // The Routing request failed
         progressDialog.dismiss();
-        Toast.makeText(this,"Something went wrong, Try again", Toast.LENGTH_SHORT).show();
+        if(e != null)
+            Toast.makeText(this, "Error: "+e.getMessage(), Toast.LENGTH_LONG).show();
+        else
+            Toast.makeText(this,"Something went wrong, Try again", Toast.LENGTH_SHORT).show();
     }
 
     @Override

--- a/sample/src/main/java/com/directions/sample/MainActivity.java
+++ b/sample/src/main/java/com/directions/sample/MainActivity.java
@@ -365,10 +365,11 @@ public class MainActivity extends AppCompatActivity implements RoutingListener, 
     public void onRoutingFailure(RouteException e) {
         // The Routing request failed
         progressDialog.dismiss();
-        if(e != null)
-            Toast.makeText(this, "Error: "+e.getMessage(), Toast.LENGTH_LONG).show();
-        else
-            Toast.makeText(this,"Something went wrong, Try again", Toast.LENGTH_SHORT).show();
+        if(e != null) {
+            Toast.makeText(this, "Error: " + e.getMessage(), Toast.LENGTH_LONG).show();
+        }else {
+            Toast.makeText(this, "Something went wrong, Try again", Toast.LENGTH_SHORT).show();
+        }
     }
 
     @Override


### PR DESCRIPTION
Currently, the onRoutingFailure callback method does not provide much useful information about the nature of the error. It could be that the API KEY is incorrect, or that the daily quota has been reached, or a bunch of other reasons. The JSON response coming from the Google servers indeed inform the user about the nature of the problem, but the library doesn't relay that information. This commit attempt to fix that.

PS. I noticed the previous pull request had some useless debug logs, thus I'm submitting another updated pull request. 