### PR TITLE
Multiple quality improvements

### DIFF
--- a/library/src/main/java/com/directions/route/RouteException.java
+++ b/library/src/main/java/com/directions/route/RouteException.java
@@ -10,8 +10,8 @@ import org.json.JSONObject;
  */
 public class RouteException extends Exception {
     private static final String TAG = "RouteException";
-    private final String KEY_STATUS = "status";
-    private final String KEY_MESSAGE = "error_message";
+    private static final String KEY_STATUS = "status";
+    private static final String KEY_MESSAGE = "error_message";
 
     private String statusCode;
     private String message;

--- a/sample/src/main/java/com/directions/sample/Util.java
+++ b/sample/src/main/java/com/directions/sample/Util.java
@@ -7,9 +7,11 @@ import android.net.NetworkInfo;
 /**
  * Created by Joel on 30/06/2015.
  */
-public class Util {
-    static public class Operations {
-
+public final class Util {
+    public static final class Operations {
+        private Operations() throws InstantiationException {
+            throw new InstantiationException("This class is not for instantiation");
+        }
         /**
          * Checks to see if the device is online before carrying out any operations.
          *
@@ -24,5 +26,8 @@ public class Util {
             }
             return false;
         }
+    }
+    private Util() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
     }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S1170 - Public constants and fields initialized at declaration should be "static final" rather than merely "final"
squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1170
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat