### PR TITLE
pmd:UseStringBufferForStringAppends - Use String Buffer For String Ap…

### DIFF
--- a/library/src/main/java/com/directions/route/AbstractRouting.java
+++ b/library/src/main/java/com/directions/route/AbstractRouting.java
@@ -60,14 +60,13 @@ public abstract class AbstractRouting extends AsyncTask<Void, Void, ArrayList<Ro
         }
 
         protected static String getRequestParam (int bit) {
-            String ret = "";
+            StringBuilder ret = new StringBuilder();
             for (AvoidKind kind : AvoidKind.values()) {
                 if ((bit & kind._sBitValue) == kind._sBitValue) {
-                    ret += kind._sRequestParam;
-                    ret += "|";
+                    ret.append(kind._sRequestParam).append('|');
                 }
             }
-            return ret;
+            return ret.toString();
         }
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule pmd:UseStringBufferForStringAppends - Use String Buffer For String Appends

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=pmd:UseStringBufferForStringAppends

Please let me know if you have any questions.

M-Ezzat