### PR TITLE
squid:S00116 - Field names should comply with a naming convention

### DIFF
--- a/library/src/main/java/com/directions/route/AbstractRouting.java
+++ b/library/src/main/java/com/directions/route/AbstractRouting.java
@@ -19,7 +19,7 @@ import java.util.List;
 
 
 public abstract class AbstractRouting extends AsyncTask<Void, Void, List<Route>> {
-    protected List<RoutingListener> _aListeners;
+    protected List<RoutingListener> alisteners;
 
     protected static final String DIRECTIONS_API_URL = "https://maps.googleapis.com/maps/api/directions/json?";
 
@@ -32,14 +32,14 @@ public abstract class AbstractRouting extends AsyncTask<Void, Void, List<Route>>
         WALKING("walking"),
         TRANSIT("transit");
 
-        protected String _sValue;
+        protected String sValue;
 
         TravelMode(String sValue) {
-            this._sValue = sValue;
+            this.sValue = sValue;
         }
 
         protected String getValue() {
-            return _sValue;
+            return sValue;
         }
     }
 
@@ -48,23 +48,23 @@ public abstract class AbstractRouting extends AsyncTask<Void, Void, List<Route>>
         HIGHWAYS (1 << 1, "highways"),
         FERRIES (1 << 2, "ferries");
 
-        private final String _sRequestParam;
-        private final int _sBitValue;
+        private final String sRequestParam;
+        private final int sBitValue;
 
         AvoidKind(int bit, String param) {
-            this._sBitValue = bit;
-            this._sRequestParam = param;
+            this.sBitValue = bit;
+            this.sRequestParam = param;
         }
 
         protected int getBitValue () {
-            return _sBitValue;
+            return sBitValue;
         }
 
         protected static String getRequestParam (int bit) {
             StringBuilder ret = new StringBuilder();
             for (AvoidKind kind : AvoidKind.values()) {
-                if ((bit & kind._sBitValue) == kind._sBitValue) {
-                    ret.append(kind._sRequestParam).append('|');
+                if ((bit & kind.sBitValue) == kind.sBitValue) {
+                    ret.append(kind.sRequestParam).append('|');
                 }
             }
             return ret.toString();
@@ -72,36 +72,36 @@ public abstract class AbstractRouting extends AsyncTask<Void, Void, List<Route>>
     }
 
     protected AbstractRouting (RoutingListener listener) {
-        this._aListeners = new ArrayList<RoutingListener>();
+        this.alisteners = new ArrayList<RoutingListener>();
         registerListener(listener);
     }
 
     public void registerListener(RoutingListener mListener) {
         if (mListener != null) {
-            _aListeners.add(mListener);
+            alisteners.add(mListener);
         }
     }
 
     protected void dispatchOnStart() {
-        for (RoutingListener mListener : _aListeners) {
+        for (RoutingListener mListener : alisteners) {
             mListener.onRoutingStart();
         }
     }
 
     protected void dispatchOnFailure(RouteException exception) {
-        for (RoutingListener mListener : _aListeners) {
+        for (RoutingListener mListener : alisteners) {
             mListener.onRoutingFailure(exception);
         }
     }
 
     protected void dispatchOnSuccess(List<Route> route, int shortestRouteIndex) {
-        for (RoutingListener mListener : _aListeners) {
+        for (RoutingListener mListener : alisteners) {
             mListener.onRoutingSuccess(route, shortestRouteIndex);
         }
     }
 
     private void dispatchOnCancelled() {
-        for (RoutingListener mListener : _aListeners) {
+        for (RoutingListener mListener : alisteners) {
             mListener.onRoutingCancelled();
         }
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S00116 - Field names should comply with a naming convention

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S00116

Please let me know if you have any questions.

M-Ezzat