### PR TITLE
Prevent exception when e.getMessage() is null in XMLParser.getInputSt…

### DIFF
--- a/library/src/main/java/com/directions/route/XMLParser.java
+++ b/library/src/main/java/com/directions/route/XMLParser.java
@@ -27,7 +27,7 @@ public class XMLParser {
         try {
             return feedUrl.openConnection().getInputStream();
         } catch (IOException e) {
-            Log.e("Routing Error", e.getMessage());
+            Log.e("Routing Error", "Exception: " + e.getMessage());
             return null;
         }
     }


### PR DESCRIPTION
…ream()

Stacktrace:
Fatal Exception: java.lang.RuntimeException: An error occured while executing doInBackground()
       at android.os.AsyncTask$3.done(AsyncTask.java:299)
       at java.util.concurrent.FutureTask.finishCompletion(FutureTask.java:352)
       at java.util.concurrent.FutureTask.setException(FutureTask.java:219)
       at java.util.concurrent.FutureTask.run(FutureTask.java:239)
       at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:230)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1080)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:573)
       at java.lang.Thread.run(Thread.java:856)
Caused by java.lang.NullPointerException: println needs a message
       at android.util.Log.println_native(Log.java)
       at android.util.Log.e(Log.java:231)
       at com.directions.route.XMLParser.getInputStream(XMLParser.java:30)
       at com.directions.route.GoogleParser.parse(GoogleParser.java:41)
       at com.directions.route.AbstractRouting.doInBackground(AbstractRouting.java:119)
       at com.directions.route.AbstractRouting.doInBackground(AbstractRouting.java:20)
       at android.os.AsyncTask$2.call(AsyncTask.java:287)
       at java.util.concurrent.FutureTask.run(FutureTask.java:234)
       at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:230)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1080)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:573)
       at java.lang.Thread.run(Thread.java:856)